### PR TITLE
Revise disable cohorting

### DIFF
--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,20 +1,21 @@
-<% if experiment.cohorting_disabled? %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
-    <input type="hidden" name="cohorting_action" value="enable">
-    <input type="submit" value="Enable Cohorting" class="green">
-  </form>
-<% else %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
-    <input type="hidden" name="cohorting_action" value="disable">
-    <input type="submit" value="Disable Cohorting" class="red">
-  </form>
-<% end %>
-<span class="divider">|</span>
 <% if experiment.has_winner? %>
   <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">
   </form>
+<% else %>
+  <% if experiment.cohorting_disabled? %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
+      <input type="hidden" name="cohorting_action" value="enable">
+      <input type="submit" value="Enable Cohorting" class="green">
+    </form>
+  <% else %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
+      <input type="hidden" name="cohorting_action" value="disable">
+      <input type="submit" value="Disable Cohorting" class="red">
+    </form>
+  <% end %>
 <% end %>
+<span class="divider">|</span>
 <% if experiment.start_time %>
   <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset()">
     <input type="submit" value="Reset Data">

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -85,9 +85,11 @@ module Split
         end
       end
 
-      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || (new_participant && @experiment.cohorting_disabled?)
+      new_participant_and_cohorting_disabled = new_participant && @experiment.cohorting_disabled?
+
+      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || new_participant_and_cohorting_disabled
       @alternative_choosen = true
-      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || (new_participant && @experiment.cohorting_disabled?) 
+      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || new_participant_and_cohorting_disabled
       alternative
     end
 


### PR DESCRIPTION
- Memoizes cohorting_disabled to prevent repeated calls to redis when calling `#cohorting_disabled?`
- Places enable/disable cohorting buttons within the else condition of `#has_winner?` ~> only displays the buttons when the experiment does not have a winner.
- Places the condition logic of `new_participant && @experiment.cohorting_disabled?` into a variable `new_participant_and_cohorting_disabled `